### PR TITLE
Functional tests support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -174,6 +174,16 @@ In most cases you won't want to have the backend in several languages, you can s
     end
   end
 
+== Testing
+
+Once your app is locale-aware, the routes are dependent on the locale. This means that in functional tests, you need to explicitly include the locale like so:
+
+  get :show, :id => 1, :locale => 'en'
+
+But in case you would prefer the locale to be implicit or simply because you don't want to add the locale param to all your previous functional tests, you can require the 'lib/controller_test_helper' file (typically from your test helper file) and then this will work fine:
+
+  get :show, :id => 1
+
 == TODO
 
 Help is welcome ;)

--- a/lib/controller_test_helper.rb
+++ b/lib/controller_test_helper.rb
@@ -1,0 +1,19 @@
+# This monkey patch injects the locale in the controller's params 
+# Reason: ActionController::TestCase doesn't support "default_url_options"
+#
+# Example: when the request you are testing needs the locale, e.g.
+#   get :show, :id => 1, :locale => 'en'
+#
+# if the monkey patch was loaded, you can just do:
+#   get :show, :id => 1
+
+class ActionController::TestCase
+
+  module Behavior
+    def process_with_default_locale(action, parameters = nil, session = nil, flash = nil, http_method = 'GET')
+      parameters = { :locale => I18n.default_locale }.merge(parameters || {} )
+      process_without_default_locale(action, parameters, session, flash, http_method)
+    end
+    alias_method_chain :process, :default_locale
+  end
+end


### PR DESCRIPTION
I added some support for functional tests. I wrote some doc in README.rdoc, so I'll let you read that first :)

I can confirm it works fine with Rails 3.1.3 and rspec-rails 2.8.1
