### PR TITLE
Option for keeping access to untranslated routes (keep_untranslated_routes)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -151,6 +151,20 @@ You can specify the following option:
 
 Note that the 'no_prefixes' option will override the 'prefix_on_default_locale' option.
 
+<b>Keep untranslated routes</b>
+
+In case you want to keep access to untranslated routes. Resulting in this structure: 
+
+  /en/available-products
+  /fr/produits-disponibles/
+  /products/
+
+You can specify the following option:
+
+  ActionDispatch::Routing::Translator.translate_from_file('config/locales/routes.yml', { :keep_untranslated_routes => true })
+
+This option is not meant to be used with :no_prefixes.
+
 <b>Namespaced backends</b>
 
 I usually build app backend in namespaced controllers, routes, ... using translated routes will result in duplicated routes or prefixed ones. In most cases you won't want to have the backend in several languages, you can set 'routes.rb' this way:

--- a/README.rdoc
+++ b/README.rdoc
@@ -153,7 +153,7 @@ Note that the 'no_prefixes' option will override the 'prefix_on_default_locale' 
 
 <b>Keep untranslated routes</b>
 
-In case you want to keep access to untranslated routes. Resulting in this structure: 
+In case you want to keep access to untranslated routes, for easier api or ajax integration for example. Resulting in this structure: 
 
   /en/available-products
   /fr/produits-disponibles/

--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -261,7 +261,7 @@ class RailsTranslateRoutes
     def translations_for route
       translated_routes = []
       available_locales.map do |locale|
-        translated_routes << translate_route route, locale
+        translated_routes << translate_route(route, locale)
       end
       
       # add untranslated_route without url helper if we want to keep untranslated routes

--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -52,6 +52,21 @@ class RailsTranslateRoutes
     @no_prefixes = no_prefixes
   end
 
+  # option allowing to keep untranslated routes 
+  # *Ex: 
+  #   *resources :users
+  #   *translated routes
+  #     en/members
+  #     fr/membres
+  #     /users
+  def keep_untranslated_routes
+    @keep_untranslated_routes ||= false
+  end
+
+  def keep_untranslated_routes= keep_untranslated_routes
+    @keep_untranslated_routes = keep_untranslated_routes
+  end
+  
   class << self
     # Default locale suffix generator
     def locale_suffix locale
@@ -244,9 +259,14 @@ class RailsTranslateRoutes
 
     # Generate translations for a single route for all available locales
     def translations_for route
+      translated_routes = []
       available_locales.map do |locale|
-        translate_route route, locale
+        translated_routes << translate_route route, locale
       end
+      
+      # add untranslated_route without url helper if we want to keep untranslated routes
+      translated_routes << untranslated_route(route) if @keep_untranslated_routes
+      translated_routes
     end
 
     # Generate translation for a single route for one locale
@@ -268,6 +288,16 @@ class RailsTranslateRoutes
       [route.app, conditions, requirements, defaults, new_name]
     end
 
+    # Re-generate untranslated routes (original routes) with name set to nil (which prevents conflict with default untranslated_urls)
+    def untranslated_route route
+      conditions = { :path_info => route.path }
+      conditions[:request_method] = parse_request_methods route.conditions[:request_method] if route.conditions.has_key? :request_method
+      requirements = route.requirements
+      defaults = route.defaults
+
+      [route.app, conditions, requirements, defaults]
+    end
+    
     # Add prefix for all non-default locales
     def add_prefix? locale
       if @no_prefixes
@@ -345,6 +375,7 @@ module ActionDispatch
           r = RailsTranslateRoutes.init_from_file(File.join(Rails.root, file_path))
           r.prefix_on_default_locale = true if options && options[:prefix_on_default_locale] == true
           r.no_prefixes = true if options && options[:no_prefixes] == true
+          r.keep_untranslated_routes = true if options && options[:keep_untranslated_routes] == true
           r.translate Rails.application.routes
         end
 

--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -292,7 +292,7 @@ class RailsTranslateRoutes
     def untranslated_route route
       conditions = {} 
       if Rails.version >= '3.2'
-        conditions[:path_info] = route.path
+        conditions[:path_info] = route.path.spec.to_s
         conditions[:request_method] = parse_request_methods route.verb if route.verb != //
         conditions[:subdomain] = route.constraints[:subdomain] if route.constraints
       else

--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -290,8 +290,15 @@ class RailsTranslateRoutes
 
     # Re-generate untranslated routes (original routes) with name set to nil (which prevents conflict with default untranslated_urls)
     def untranslated_route route
-      conditions = { :path_info => route.path }
-      conditions[:request_method] = parse_request_methods route.conditions[:request_method] if route.conditions.has_key? :request_method
+      conditions = {} 
+      if Rails.version >= '3.2'
+        conditions[:path_info] = route.path
+        conditions[:request_method] = parse_request_methods route.verb if route.verb != //
+        conditions[:subdomain] = route.constraints[:subdomain] if route.constraints
+      else
+        conditions[:path_info] = route.path
+        conditions[:request_method] = parse_request_methods route.conditions[:request_method] if route.conditions.has_key? :request_method
+      end
       requirements = route.requirements
       defaults = route.defaults
 


### PR DESCRIPTION
I added this option to allow the following routes structure

default_locale = :en

/en/translated-products
/fr/translated-produits
/products

I used this config in production in a Rails 3.1 project and just updated it to fit 3.2 requirements.
