### PR TITLE
Locales without downcase

### DIFF
--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -322,7 +322,7 @@ class RailsTranslateRoutes
       path_without_optional_segments = final_optional_segments ? path.gsub(final_optional_segments,'') : path
       path_segments = path_without_optional_segments.split("/")
       new_path = path_segments.map{ |seg| translate_path_segment(seg, locale) }.join('/')
-      new_path = "/#{locale.downcase}#{new_path}" if add_prefix?(locale)
+      new_path = "/#{locale}#{new_path}" if add_prefix?(locale)
       new_path = '/' if new_path.blank?
       final_optional_segments ? new_path + final_optional_segments : new_path
     end


### PR DESCRIPTION
I removed the call to the downcase function in the creation of routes because there are some locales that use the caps letters. For instance, simplified chinese is "zh-CN". And it's kind of weird having all the rails urls with zh-CN except the translated ones.

The only drawback is that it has to be well written in the YAML, but I think it's the correct way.

Thanks!
