### PR TITLE
Allow for international characters in translations

### DIFF
--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -352,7 +352,8 @@ class RailsTranslateRoutes
     end
 
     def translate_string str, locale
-      @dictionary[locale.to_s][str.to_s]
+      translation = @dictionary[locale.to_s][str.to_s]
+      translation.present? ? Rack::Utils.escape(translation) : translation
     end
 
     private


### PR DESCRIPTION
My app was choking on a translation `über` because it contained an Umlaut.

So made an update to escape the output of the `translate_string` method if necessary.
