### PR TITLE
Resque route is broken

### DIFF
--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -293,10 +293,11 @@ class RailsTranslateRoutes
         defaults = route.defaults.merge LOCALE_PARAM_KEY => locale
       end
 
+      anchored = route.path.anchored
       requirements = route.requirements.merge LOCALE_PARAM_KEY => locale
       new_name = "#{route.name}_#{locale_suffix(locale)}" if route.name
 
-      [route.app, conditions, requirements, defaults, new_name]
+      [route.app, conditions, requirements, defaults, new_name, anchored]
     end
 
     # Re-generate untranslated routes (original routes) with name set to nil (which prevents conflict with default untranslated_urls)


### PR DESCRIPTION
I use `Resque::Server` in my routes and, for some reason, when I use rails-translate-routes, it breaks it.

``` ruby
require 'resque/server'

Ubiquity::Application.routes.draw do
  mount Resque::Server.new, :at => "/resque"
end

ActionDispatch::Routing::Translator.translate_from_file('config/locales/routes.yml', no_prefixes: true)
```

It generates a routing error:

```
No route matches [GET] "/resque"
```
