### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ A simple example of a redirection to user locale in index method:
     def index
       unless params[ :locale]
         # it takes I18n.locale from the previous example set_locale as before_filter in application controller
-        redirect_to eval("root_#{I18n.locale}_path")
+        redirect_to eval("root_#{I18n.locale}_path") and return
       end
 
       # rest of the controller logic ...


### PR DESCRIPTION
Added `and return` after `redirect_to root_locale_path` to avoid multiple rendering.

What about suggesting http_accept_language to fetch correct language from user browser?
