### PR TITLE
Support :locale option for untranslated helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ And that's it! Now if we execute `rake routes`
             root_en        /                                {:controller=>"public", :action=>"index"}
             root_es        /es                              {:controller=>"public", :action=>"index"}
 
-The application recognizes the different routes and sets the `I18n.locale` value in controllers, but what about the routes generation? As you can see on the previous rake routes execution, the `contact_es_path` and `contact_en_path` routing helpers have been generated and are available in your controllers and views. Additionally, a `contact_path` helper has been generated, which generates the routes according to the current request's locale. This means that if you use named routes you don't need to modify your application links because the routing helpers are automatically adapted to the current locale.
+The application recognizes the different routes and sets the `I18n.locale` value in controllers, but what about the routes generation? As you can see on the previous rake routes execution, the `contact_es_path` and `contact_en_path` routing helpers have been generated and are available in your controllers and views. Additionally, a `contact_path` helper has been generated, which generates the routes according to the current request's locale (if no explicit `:locale` option is given). This means that if you use named routes you don't need to modify your application links because the routing helpers are automatically adapted to the current locale.
 
 ## URL structure options
 

--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -250,13 +250,18 @@ class RailsTranslateRoutes
     #   people_path -> people_de_path
     #   I18n.locale = :fr
     #   people_path -> people_fr_path
+    # May also be called with explicit :locale option, e.g.
+    #   user_path(1, :locale => :en) -> user_en_path(1)
     def add_untranslated_helpers_to_controllers_and_views old_name
       ['path', 'url'].map do |suffix|
         new_helper_name = "#{old_name}_#{suffix}"
 
         ROUTE_HELPER_CONTAINER.each do |helper_container|
           helper_container.send :define_method, new_helper_name do |*args|
-            send "#{old_name}_#{locale_suffix(I18n.locale)}_#{suffix}", *args
+            options = args.extract_options!
+            locale = options.delete(:locale) || I18n.locale
+            args << options if options.present?
+            send "#{old_name}_#{locale_suffix(locale)}_#{suffix}", *args
           end
         end
 


### PR DESCRIPTION
I found it helpful to be able to use e.g. `root_path(:locale => :en)` (especially when the :locale option is dynamic, e.g. for a language switcher).
