### PR TITLE
Constantize class names before we use them

### DIFF
--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -9,9 +9,9 @@ class RailsTranslateRoutes
   def self.route_helper_container
     @route_helper_container ||= begin
       classes = ['ActionController::Base',
-                 'ActionView::Base',
                  'ActionMailer::Base',
-                 'ActionDispatch::Routing::UrlFor']
+                 'ActionDispatch::Routing::UrlFor',
+                 'ActionDispatch::Routing::RouteSet::MountedHelpers']
 
       classes.map! do |klass_name|
         begin

--- a/lib/rails-translate-routes.rb
+++ b/lib/rails-translate-routes.rb
@@ -5,12 +5,24 @@
 class RailsTranslateRoutes
   TRANSLATABLE_SEGMENT = /^([\w-]+)(\()?/.freeze
   LOCALE_PARAM_KEY = :locale.freeze
-  ROUTE_HELPER_CONTAINER = [
-    ActionController::Base,
-    ActionView::Base,
-    ActionMailer::Base,
-    ActionDispatch::Routing::UrlFor
-  ].freeze
+
+  def self.route_helper_container
+    @route_helper_container ||= begin
+      classes = ['ActionController::Base',
+                 'ActionView::Base',
+                 'ActionMailer::Base',
+                 'ActionDispatch::Routing::UrlFor']
+
+      classes.map! do |klass_name|
+        begin
+          klass_name.constantize
+        rescue NameError
+          nil
+        end
+      end
+      classes.compact
+    end
+  end
 
   # Attributes
 
@@ -254,7 +266,7 @@ class RailsTranslateRoutes
       ['path', 'url'].map do |suffix|
         new_helper_name = "#{old_name}_#{suffix}"
 
-        ROUTE_HELPER_CONTAINER.each do |helper_container|
+        self.class.route_helper_container.each do |helper_container|
           helper_container.send :define_method, new_helper_name do |*args|
             send "#{old_name}_#{locale_suffix(I18n.locale)}_#{suffix}", *args
           end
@@ -416,7 +428,7 @@ ActionController::Base.class_eval do
 end
 
 # Add locale_suffix to controllers, views and mailers
-RailsTranslateRoutes::ROUTE_HELPER_CONTAINER.each do |klass|
+RailsTranslateRoutes.route_helper_container.each do |klass|
   klass.class_eval do
     private
     def locale_suffix locale


### PR DESCRIPTION
The items in `ROUTE_HELPER_CONTAINER` were constants from different Rails components and if we try to use the gem in a Rails project without all of those components (eg. without `ActionMailer`), it would break.

This pull request makes sure the constants we use exist before we try to inject code in them.
